### PR TITLE
Add method extension to classes to differ WMS/WCS classes

### DIFF
--- a/ceda/tds_ogc_scan/test/factory.py
+++ b/ceda/tds_ogc_scan/test/factory.py
@@ -15,12 +15,13 @@ class ThreddsCatalogUnittestCaseFactory:
     '''Create a unittest case class for testing endpoints from a THREDDS
     catalogue
     '''
-    def __init__(self, catalog_uri, unittest_method_factory):
+    def __init__(self, catalog_uri, unittest_method_factory, method_extension=None):
         '''Provide the URI to the THREDDS catalogue + a unit test method
         factory which generates the tests needed
         '''
         self.catalog_uri = catalog_uri
         self.unittest_method_factory = unittest_method_factory
+        self.method_extension = method_extension
 
     def _gen_unittest_methods(self):
         '''Make a list of unittest methods based on contents of a THREDDS 
@@ -39,7 +40,10 @@ class ThreddsCatalogUnittestCaseFactory:
         _attr = {}
         method_factories = self._gen_unittest_methods()
         for i, unittest_method in enumerate(method_factories, start=1):
-            _attr['test_{:03d}'.format(i)] = unittest_method
+            method_extension = ''
+            if self.method_extension is not None:
+                method_extension = '_{}'.format(self.method_extension)
+            _attr['test_{:03d}{}'.format(i, method_extension)] = unittest_method
 
         TdsCatalogServiceTestCase = type('TdsCatalogServiceTestCase',
                                          (unittest.TestCase, ), _attr)

--- a/ceda/tds_ogc_scan/test/test_wcs.py
+++ b/ceda/tds_ogc_scan/test/test_wcs.py
@@ -73,7 +73,8 @@ def tds_wcs_testcase_factory(catalog_uri):
     '''Create TDS WCS TestCase class'''
     unittest_case_factory = ThreddsCatalogUnittestCaseFactory(
                                                 catalog_uri,
-                                                TdsWcsUnittestMethodFactory)
+                                                TdsWcsUnittestMethodFactory,
+                                                method_extension='wcs')
     return unittest_case_factory()
     
         

--- a/ceda/tds_ogc_scan/test/test_wms.py
+++ b/ceda/tds_ogc_scan/test/test_wms.py
@@ -76,7 +76,8 @@ def tds_wms_testcase_factory(catalog_uri):
     '''Create TDS WMS TestCase class'''
     unittest_case_factory = ThreddsCatalogUnittestCaseFactory(
                                                 catalog_uri,
-                                                TdsWmsUnittestMethodFactory)
+                                                TdsWmsUnittestMethodFactory,
+                                                method_extension='wms')
     
     return unittest_case_factory()
 


### PR DESCRIPTION
An attribute `method_extension` has been added to the `ThreddsCatalogUnittestCaseFactory` class. This is a feature to be used for the cci-metrics repo, where Flask doesn't allow two identically named endpoints despite them being in separate classes (wms and wcs classes). This change allows the endpoints to be different (e.g. 'test_001_wms'). This attribute is set to `None` by default, so can be ignored if needed.